### PR TITLE
Frontpage: remove Meetup.com link since inactive

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -6,7 +6,6 @@ title: Malmö.rb
   <%= image_tag 'logo.png', alt: 'Malmö.rb', title: 'Malmö.rb' %>
   <p class="doc">
     <%= link_to "Slack", "http://oreslack.herokuapp.com" %> |
-    <%= link_to "Meetup", "http://www.meetup.com/malmo-ruby/" %> |
     <%= link_to "Mailinglist",
     "https://groups.google.com/forum/?fromgroups#!forum/malmorb" %>
     | <a href="http://twitter.com/malmorb">Twitter</a> |


### PR DESCRIPTION
This PR removes the now-inactive Meetup.com link from the Malmorb website.

