### PR TITLE
January 2019 event page start

### DIFF
--- a/helpers/formatting_helpers.rb
+++ b/helpers/formatting_helpers.rb
@@ -2,4 +2,8 @@ module FormattingHelpers
   def short_date(value)
     value.to_date.strftime('%b %-d')
   end
+
+  def iso_date(value)
+    value.to_date.strftime('%Y-%m-%d')
+  end
 end

--- a/source/about/malmorb.html.erb
+++ b/source/about/malmorb.html.erb
@@ -1,0 +1,11 @@
+---
+layout: page
+title: About Malmö.rb
+---
+
+<h3>What is Malmö.rb?</h3>
+
+<p>
+	A group of enthusiasts about Ruby who meet regularly,
+	to talk about technical things.
+</p>

--- a/source/about/past_events.html.erb
+++ b/source/about/past_events.html.erb
@@ -1,0 +1,17 @@
+---
+layout: page
+title: Past events
+---
+
+<p>
+Events for which we didn't keep a page at this website.
+</p>
+
+
+<% data.past_events.sort_by {|o| o[:date] }.reverse.each do |event| %>
+  <div>
+    <%= iso_date event['date'] %> <em>
+      <%= link_to event['link_text'], event['url'] %>
+    </em>
+  </div>
+<% end %>

--- a/source/about/ruby.html.erb
+++ b/source/about/ruby.html.erb
@@ -1,0 +1,34 @@
+---
+layout: page
+title: About Ruby
+---
+
+<h3>What is Ruby?</h3>
+
+<h4>It's a programming language</h4>
+
+<p>
+	Optimized for programmer happiness, it says.
+</p>
+
+<p>
+	Made in Japan.
+</p>
+
+<p>
+	Started in 1995.
+</p>
+
+<p>
+	<a href="https://en.wikipedia.org/wiki/Ruby_(programming_language)">Wikipedia page on Ruby</a>
+</p>
+
+<h4>Is it used?</h4>
+<p>
+  Ruby is one of
+  <a href="https://www.businessinsider.com/the-10-most-popular-programming-languages-according-to-github-2018-10">the 10 most popular programming languages, according to GitHub in 2018</a>.
+</p>
+
+<p>
+  Ruby has enjoyed being in the top-10 of the TIOBE index for a 10-year consecutive period.
+</p>

--- a/source/events/2019/meetup-january.html.erb
+++ b/source/events/2019/meetup-january.html.erb
@@ -1,0 +1,51 @@
+---
+
+date: 2019-01-08
+location: Skeppsbron 3. Ring the electronic bell for eCraft.
+theme:
+  name: "Theme: Game tooling & Ruby 2.6"
+  description: |
+    Join us for our January 8 meetup where we have Jens Nockert talking <b>about game tools</b>. There will also be <b>a Ruby 2.6 safari tour</b> of what is new in that programming language.
+
+    <h3>Target Audience</h3>
+    <p>This is a free event for people interested in Ruby.
+    <p>
+    We welcome both experienced programmers and total beginners to our events. In fact, we take great pride in making a welcoming atmosphere to newcomers to tech.
+    </p>
+
+planned_activities_description: |
+  We'll have a string of talks for you, interpolated by some snacks and time to
+  meet the other attendees.
+speakers:
+  - name: Jens Nockert
+    talk_title: Using Ruby in your game asset pipeline
+    talk_description: |
+      Taking a deep look at extending an old and working asset pipeline based around RAD Granny 3D and bringing it to the web with Ruby, Rake, and liberal application of a hex editor. We’ll look at the open-source (and official) EVE: Online renderer <a href=https://github.com/ccpgames/ccpwgl>CCPWGL</a> and its assets as a case study.
+
+      <p>There will be Ruby, C and JavaScript shown, but only basic programming knowledge will be assumed.</p>
+
+      <p>No game or Ruby experience required.</p>
+
+  - name: Someone Else
+    talk_title: What is new in Ruby 2.6?
+    talk_description: |
+      Some holidays bring a new Ruby version, this time we got Ruby 2.6. What changed? What new patterns emerge? What can you do with the new features? What new magic is possible?
+
+      <p>There will be examples, there will be explanations.</p>
+
+
+signup_link:
+---
+
+<h3>What is Ruby?</h3>
+
+<p>
+  Ruby is a programming language which says it "optimizes
+  for programmer happiness". We've started a separate
+  <a href="/about/ruby.html">Introduction to Ruby page</a>,
+  to get you up to speed.
+</p>
+
+<h3>The location</h3>
+
+<p>It's on the first floor, but there's an elevator.</p>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -1,11 +1,11 @@
 ---
 title: "Malmö.rb: Malmö Ruby user group"
 current_event:
-  description: "Explore Ruby together - next meetup December 4! "
-  date: "2018-12-04"
-  link_text: "Theme to be decided"
+  description: "Explore Ruby together - next meetup January 8! "
+  date: "2019-01-08"
+  link_text: "Theme: Game tooling & Ruby 2.6"
   location: "eCraft - Skeppsbron 3, Malmö"
-  url: "https://github.com/malmorb/malmorb.github.com/issues/23"
+  url: "/events/meetup-january.html"
 ---
 
 <div class="welcome">

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -21,8 +21,7 @@ current_event:
 
   <div class="grid">
     <div class="card who-we-are">
-      <p>A group of Ruby enthusiasts from sunny Malmö, Sweden who meet about every
-        month to talk about Ruby, programming, and other related topics.</p>
+      <p>A group of <strong>Ruby</strong> enthusiasts from sunny <strong>Malmö</strong>, Sweden who meet regularly to talk about Ruby, programming, and related topics.</p>
     </div>
 
     <div class="card events">
@@ -39,12 +38,6 @@ current_event:
       <p><strong>Future</strong>: Do you want to do a talk or some other activity?
         Get in touch, join that Slack and mailing list!</p>
 
-      <p><strong>Past</strong>:
-        <% data.past_events.sort_by {|o| o[:date] }.reverse.each do |event| %>
-            <%= short_date event['date'] %> <em>
-              <%= link_to event['link_text'], event['url'] %>
-            </em>
-        <% end %>
     </div>
 
     <div class="card using-ruby">

--- a/source/layouts/page.erb
+++ b/source/layouts/page.erb
@@ -1,0 +1,9 @@
+<% wrap_layout :layout do %>
+  <article class="about-page">
+	<h2>
+		<%= data['page']['title'] %>
+	</h2>
+
+    <%= yield %>
+  </article>
+<% end %>

--- a/source/stylesheets/all.css
+++ b/source/stylesheets/all.css
@@ -113,3 +113,18 @@ h2 {
 .event-page h4 {
   font-size: 150%;
 }
+
+/* Pages in /about/ have this. */
+.about-page {
+  margin-right: 2em;
+  margin-left: 2em;
+}
+.about-page h2 {
+  font-size: 300%;
+}
+.about-page h3 {
+  font-size: 175%;
+}
+.about-page h4 {
+  font-size: 150%;
+}


### PR DESCRIPTION
This PR adds two pages and an event page description for Jan 8 2019.

# TODO

- [x] link on front page
- [x] perhaps an About page about Previous events (which only have links)
- [ ] way more CSS styling of the pages